### PR TITLE
Cache the last timestamp synced

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -12,10 +12,14 @@ jobs:
         channel: ["880245221840003112"]
     runs-on: ubuntu-latest
     steps:
-
     - uses: actions/checkout@v2
 
     - uses: mskelton/setup-yarn@v1
+
+    - uses: actions/cache@v2
+      with:
+        path: last_synced
+        key: last_synced
 
     - run: yarn ts-node ./checkSales.ts
       env:
@@ -24,4 +28,3 @@ jobs:
         DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
         DISCORD_CHANNEL_ID: ${{ matrix.channel }}
         OPENSEA_API_TOKEN: ${{ secrets.OPENSEA_API_TOKEN }}
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 node_modules
 .DS_Store
+last_synced


### PR DESCRIPTION
Uses Github's [cache action](https://github.com/actions/cache) to cache the last timestamp we successfully synced at. This makes us more resilient to OpenSea outages / breaking changes.

I preset the cache with 1 millisecond after the last sale we posted to discord [here](https://github.com/thousandetherhomepage/opensea-discord-bot/commit/64d95ae9f1ea114bc01e1c385a2ebb716d2864ae). We can edit that file and manually trigger the workflow if we ever need to manually bust the cache.

If we merge this we'll get all the sales we missed.

You can see a test (logging only) for example here: https://github.com/thousandetherhomepage/opensea-discord-bot/runs/5559696935?check_suite_focus=true

Note: as is we will post sales in reverse chronological order. I'm okay with this.